### PR TITLE
Sobre escritura de URL

### DIFF
--- a/src/Class/AfipWebService.js
+++ b/src/Class/AfipWebService.js
@@ -77,6 +77,8 @@ module.exports = class AfipWebService {
 			};
 
 			this.soapClient = await soap.createClientAsync(this.WSDL, soapClientOptions);
+			/* Sobre escribir la URL del archivo .wsdl */
+			this.soapClient.setEndpoint(this.URL);
 		}
 
 		// Call to SOAP method


### PR DESCRIPTION
A diferencia de la versión para PHP, ésta no tomaba el parámetro URL del objeto sino que tomaba el que estaba dentro del archivo .wsdl lo que causaba un timeout ya que AFIP parece no estar atendiendo el puerto 80. Como el archivo tenia http y no https el comando getPersona no funcionaba. Revisar si se puede generar nuevo tag para que aparezca también el cambio de @GrrAmd2 y que npm baje la última versión con estos cambios.