### PR TITLE
fix(types): tipado de opciones en new Afip()

### DIFF
--- a/src/Afip.js
+++ b/src/Afip.js
@@ -19,8 +19,27 @@ const RegisterScopeThirteen = require('./Class/RegisterScopeThirteen');
  * @author Afip SDK <ayuda@afipsdk.com>
  * @package Afip
  **/
+
+/**
+ * @typedef {Object} AfipOptions
+ * @property {number|string} [CUIT] Tax ID to use
+ * @property {boolean} [production=false] Use production environment
+ * @property {string} [cert] X.509 certificate in PEM format
+ * @property {string} [key] Private key corresponding to cert (PEM)
+ * @property {string} [access_token] Access token from AfipSDK
+ */
+
 module.exports = Afip;
 
+/**
+ * @param {{
+ *  CUIT?: number|string,
+ *  production?: boolean,
+ *  cert?: string,
+ *  key?: string,
+ *  access_token?: string
+ * }} [options={}]
+ */
 function Afip(options = {}){
 	/**
 	 * SDK version

--- a/src/Afip.js
+++ b/src/Afip.js
@@ -26,15 +26,16 @@ const RegisterScopeThirteen = require('./Class/RegisterScopeThirteen');
  * @property {boolean} [production=false] Use production environment
  * @property {string} [cert] X.509 certificate in PEM format
  * @property {string} [key] Private key corresponding to cert (PEM)
- * @property {string} [access_token] Access token from AfipSDK
+ * @property {string} access_token Access token from AfipSDK
  */
 
 module.exports = Afip;
 
 /**
- * @param {AfipOptions} [options={}]
+ * @param {AfipOptions} options
  */
-function Afip(options = {}){
+function Afip(options){
+	options = options || {};
 	/**
 	 * SDK version
 	 **/

--- a/src/Afip.js
+++ b/src/Afip.js
@@ -32,13 +32,7 @@ const RegisterScopeThirteen = require('./Class/RegisterScopeThirteen');
 module.exports = Afip;
 
 /**
- * @param {{
- *  CUIT?: number|string,
- *  production?: boolean,
- *  cert?: string,
- *  key?: string,
- *  access_token?: string
- * }} [options={}]
+ * @param {AfipOptions} [options={}]
  */
 function Afip(options = {}){
 	/**

--- a/types/Afip.d.ts
+++ b/types/Afip.d.ts
@@ -1,48 +1,18 @@
 export = Afip;
 /**
- * @param {{
- *  CUIT?: number|string,
- *  production?: boolean,
- *  cert?: string,
- *  key?: string,
- *  access_token?: string
- * }} [options={}]
+ * @param {AfipOptions} [options={}]
  */
-declare function Afip(options?: {
-    CUIT?: number | string;
-    production?: boolean;
-    cert?: string;
-    key?: string;
-    access_token?: string;
-}): Afip;
+declare function Afip(options?: AfipOptions): Afip;
 declare class Afip {
     /**
-     * @param {{
-     *  CUIT?: number|string,
-     *  production?: boolean,
-     *  cert?: string,
-     *  key?: string,
-     *  access_token?: string
-     * }} [options={}]
+     * @param {AfipOptions} [options={}]
      */
-    constructor(options?: {
-        CUIT?: number | string;
-        production?: boolean;
-        cert?: string;
-        key?: string;
-        access_token?: string;
-    });
+    constructor(options?: AfipOptions);
     /**
      * SDK version
      **/
     sdk_version_number: string;
-    options: {
-        CUIT?: number | string;
-        production?: boolean;
-        cert?: string;
-        key?: string;
-        access_token?: string;
-    };
+    options: AfipOptions;
     CUIT: string | number;
     CERT: string;
     PRIVATEKEY: string;
@@ -122,13 +92,6 @@ declare class Afip {
 declare namespace Afip {
     export { AfipOptions };
 }
-import ElectronicBilling = require("./Class/ElectronicBilling");
-import RegisterScopeFour = require("./Class/RegisterScopeFour");
-import RegisterScopeFive = require("./Class/RegisterScopeFive");
-import RegisterInscriptionProof = require("./Class/RegisterInscriptionProof");
-import RegisterScopeTen = require("./Class/RegisterScopeTen");
-import RegisterScopeThirteen = require("./Class/RegisterScopeThirteen");
-import AfipWebService = require("./Class/AfipWebService");
 type AfipOptions = {
     /**
      * Tax ID to use
@@ -151,3 +114,10 @@ type AfipOptions = {
      */
     access_token?: string;
 };
+import ElectronicBilling = require("./Class/ElectronicBilling");
+import RegisterScopeFour = require("./Class/RegisterScopeFour");
+import RegisterScopeFive = require("./Class/RegisterScopeFive");
+import RegisterInscriptionProof = require("./Class/RegisterInscriptionProof");
+import RegisterScopeTen = require("./Class/RegisterScopeTen");
+import RegisterScopeThirteen = require("./Class/RegisterScopeThirteen");
+import AfipWebService = require("./Class/AfipWebService");

--- a/types/Afip.d.ts
+++ b/types/Afip.d.ts
@@ -1,13 +1,13 @@
 export = Afip;
 /**
- * @param {AfipOptions} [options={}]
+ * @param {AfipOptions} options
  */
-declare function Afip(options?: AfipOptions): Afip;
+declare function Afip(options: AfipOptions): Afip;
 declare class Afip {
     /**
-     * @param {AfipOptions} [options={}]
+     * @param {AfipOptions} options
      */
-    constructor(options?: AfipOptions);
+    constructor(options: AfipOptions);
     /**
      * SDK version
      **/
@@ -112,7 +112,7 @@ type AfipOptions = {
     /**
      * Access token from AfipSDK
      */
-    access_token?: string;
+    access_token: string;
 };
 import ElectronicBilling = require("./Class/ElectronicBilling");
 import RegisterScopeFour = require("./Class/RegisterScopeFour");

--- a/types/Afip.d.ts
+++ b/types/Afip.d.ts
@@ -1,15 +1,51 @@
 export = Afip;
-declare function Afip(options?: {}): Afip;
+/**
+ * @param {{
+ *  CUIT?: number|string,
+ *  production?: boolean,
+ *  cert?: string,
+ *  key?: string,
+ *  access_token?: string
+ * }} [options={}]
+ */
+declare function Afip(options?: {
+    CUIT?: number | string;
+    production?: boolean;
+    cert?: string;
+    key?: string;
+    access_token?: string;
+}): Afip;
 declare class Afip {
-    constructor(options?: {});
+    /**
+     * @param {{
+     *  CUIT?: number|string,
+     *  production?: boolean,
+     *  cert?: string,
+     *  key?: string,
+     *  access_token?: string
+     * }} [options={}]
+     */
+    constructor(options?: {
+        CUIT?: number | string;
+        production?: boolean;
+        cert?: string;
+        key?: string;
+        access_token?: string;
+    });
     /**
      * SDK version
      **/
     sdk_version_number: string;
-    options: {};
-    CUIT: any;
-    CERT: any;
-    PRIVATEKEY: any;
+    options: {
+        CUIT?: number | string;
+        production?: boolean;
+        cert?: string;
+        key?: string;
+        access_token?: string;
+    };
+    CUIT: string | number;
+    CERT: string;
+    PRIVATEKEY: string;
     /** @private */
     private AdminClient;
     ElectronicBilling: ElectronicBilling;
@@ -83,6 +119,9 @@ declare class Afip {
         data?: any;
     }>;
 }
+declare namespace Afip {
+    export { AfipOptions };
+}
 import ElectronicBilling = require("./Class/ElectronicBilling");
 import RegisterScopeFour = require("./Class/RegisterScopeFour");
 import RegisterScopeFive = require("./Class/RegisterScopeFive");
@@ -90,3 +129,25 @@ import RegisterInscriptionProof = require("./Class/RegisterInscriptionProof");
 import RegisterScopeTen = require("./Class/RegisterScopeTen");
 import RegisterScopeThirteen = require("./Class/RegisterScopeThirteen");
 import AfipWebService = require("./Class/AfipWebService");
+type AfipOptions = {
+    /**
+     * Tax ID to use
+     */
+    CUIT?: number | string;
+    /**
+     * Use production environment
+     */
+    production?: boolean;
+    /**
+     * X.509 certificate in PEM format
+     */
+    cert?: string;
+    /**
+     * Private key corresponding to cert (PEM)
+     */
+    key?: string;
+    /**
+     * Access token from AfipSDK
+     */
+    access_token?: string;
+};


### PR DESCRIPTION
## Resumen
- Se agrega `AfipOptions` con propiedades tipadas para el constructor (`CUIT`, `production`, `cert`, `key`, `access_token`).
- Se aplica `AfipOptions` en `declare function Afip`, `constructor` y `options`.

## Contexto
Linear: CLEVEL-297
