### PR TITLE
CLEVEL-339 (WIP): add createPDF template+params contract docs and example

### DIFF
--- a/examples/createPDFWithTemplate.js
+++ b/examples/createPDFWithTemplate.js
@@ -1,0 +1,27 @@
+const Afip = require('../src/Afip');
+
+const afip = new Afip({
+  CUIT: 20409378472,
+  access_token: process.env.AFIPSDK_ACCESS_TOKEN,
+  production: false
+});
+
+async function main () {
+  const response = await afip.ElectronicBilling.createPDF({
+    template: 'invoice_b',
+    params: {
+      voucherNumber: '00000001',
+      issueDate: '25/02/2026',
+      issuerCuit: '20409378472',
+      cae: '86080011752811',
+      caeDueDate: '07/03/2026',
+      ivaAmount: '21,00',
+      qrCode: 'https://www.afip.gob.ar/fe/qr/?p=...'
+    },
+    file_name: 'factura-b-ejemplo'
+  });
+
+  console.log(response);
+}
+
+main().catch(console.error);

--- a/src/Class/ElectronicBilling.js
+++ b/src/Class/ElectronicBilling.js
@@ -26,6 +26,13 @@ module.exports = class ElectronicBilling extends AfipWebService {
 	 * Send a request to Afip SDK server to create a PDF
 	 *
 	 * @param {object} data Data for PDF creation
+	 *
+	 * Supported modes:
+	 * - Legacy: `{ html, file_name?, options? }`
+	 * - Template: `{ template, params, file_name?, options? }`
+	 *
+	 * Template mode lets you render server-side templates by name
+	 * and pass dynamic values with `params`.
 	 **/
 	async createPDF(data)
 	{

--- a/types/Class/ElectronicBilling.d.ts
+++ b/types/Class/ElectronicBilling.d.ts
@@ -7,6 +7,10 @@ declare class ElectronicBilling extends AfipWebService {
      * Send a request to Afip SDK server to create a PDF
      *
      * @param {object} data Data for PDF creation
+     *
+     * Supported modes:
+     * - Legacy: `{ html, file_name?, options? }`
+     * - Template: `{ template, params, file_name?, options? }`
      **/
     createPDF(data: object): Promise<{
         file: any;


### PR DESCRIPTION
## Context
Initial WIP for CLEVEL-339.

## Included
- Documented `createPDF` support for both modes:
  - Legacy: `{ html, ... }`
  - Template: `{ template, params, ... }`
- Added template-mode example: `examples/createPDFWithTemplate.js`
- Updated generated d.ts JSDoc accordingly.

## Next
- Implement template catalog and validation matrix for documented voucher types.